### PR TITLE
Update React Router

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -36,7 +36,7 @@ module.exports = class PinguGenerator extends Generator {
       'lodash',
       'redux',
       'react-redux',
-      'react-router-dom@next',
+      'react-router-dom',
       'react-router-redux',
       'redux-saga',
     ];


### PR DESCRIPTION
React Router 4.0.0 was released on the weekend so we can remove the `next` version.