### PR TITLE
Feature/declare immutable state

### DIFF
--- a/app/templates/src/default-state.js
+++ b/app/templates/src/default-state.js
@@ -1,4 +1,5 @@
-export const defaultState = {
-};
+import { fromJS } from 'immutable';
+
+export const defaultState = fromJS({});
 
 export default defaultState;

--- a/redux/templates/reducer.js
+++ b/redux/templates/reducer.js
@@ -1,13 +1,15 @@
+import { Record } from 'immutable';
+
 import { MY_ACTION_TYPE } from '../actions/<%= dashed %>';
 
 const handlers = {
   [MY_ACTION_TYPE]: (state, action) => {
     // Modify state.
-    return { ...state };
+    return Record(state);
   },
 };
 
-const defaultState = {};
+const defaultState = Record({});
 
 export default function reducer(state = defaultState, action) {
   return handlers[action.type] ? handlers[action.type](state, action) : state;


### PR DESCRIPTION
Since `immutable` is already a dependency, the template code should actually leverage the library.