### PR TITLE
Automatically create or update barrel file

### DIFF
--- a/component/templates/barrel.js
+++ b/component/templates/barrel.js
@@ -1,0 +1,1 @@
+export * from './<%= dashed %>';


### PR DESCRIPTION
This addition to the generator will create a new `index.js` file under `src/components/<tier>/` with statements like:

```
export * from './my-component';
```

This allows us to do «mass» imports from another template, e.g.:

```
import { AboutPage, HomePage, ImpressPage } from './src/components/pages';
```